### PR TITLE
Improve text-to-speech queue handling

### DIFF
--- a/cogs/LeagueGameStatus.py
+++ b/cogs/LeagueGameStatus.py
@@ -24,13 +24,11 @@ praises = []
 
 # Load PraiseFiles
 async def loadPraise():
-    file = open("cogs/PraiseFiles/praises.txt", "r")
-
-    for line in file:
-        stripped_line = line.strip()
-        praises.append(stripped_line.split('||')[0])
-
-    file.close()
+    praises.clear()
+    with open("cogs/PraiseFiles/praises.txt", "r") as file:
+        for line in file:
+            stripped_line = line.strip()
+            praises.append(stripped_line.split('||')[0])
 
 
 # Helper function to get list of friends
@@ -63,6 +61,10 @@ class LeagueGameStatus(commands.Cog):
         During a game of league of legends, if any of your friends die: give them a praise!
         """
         try:
+            voice_client = ctx.voice_client
+            if voice_client is None or not voice_client.is_connected():
+                await ctx.send("I'm not connected to a voice channel. Use `!join` before starting the monitor.")
+                return
             await loadPraise()
             friends = _get_all_friends()
 

--- a/cogs/TextToSpeechFiles/TextToSpeech.py
+++ b/cogs/TextToSpeechFiles/TextToSpeech.py
@@ -1,34 +1,94 @@
 # Imports
+import asyncio
 import os
 import re
+import uuid
+from pathlib import Path
+from typing import Optional
 
 import discord
 from gtts import gTTS
 from discord import ClientException
 from discord.opus import OpusNotLoaded
 
+_play_locks: dict[int, asyncio.Lock] = {}
+
+
+def _get_guild_id(ctx) -> int:
+    guild = getattr(ctx, "guild", None)
+    if guild is not None:
+        return guild.id
+    voice_client = getattr(ctx, "voice_client", None)
+    if voice_client is not None and voice_client.guild is not None:
+        return voice_client.guild.id
+    return 0
+
+
+async def _wait_for_completion(ctx, voice_client: discord.VoiceClient, source: discord.AudioSource) -> None:
+    done = asyncio.Event()
+
+    def _after_playback(error: Optional[Exception]) -> None:
+        if error:
+            print(f"Error while playing audio: {error}")
+        loop = getattr(ctx, "loop", None)
+        if loop is None and hasattr(ctx, "bot"):
+            loop = ctx.bot.loop
+        if loop is None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+        if loop is not None:
+            loop.call_soon_threadsafe(done.set)
+
+    voice_client.play(source, after=_after_playback)
+    await done.wait()
+
 
 # Helper function to vocalize text
 async def vocalizeText(ctx, text, language) -> None:
-    """
-    Play the text in the designated voice_client in the prompted language
-    """
-    folder_path = "cogs/TextToSpeechFiles"
-    os.makedirs(folder_path, exist_ok=True)
+    """Play the text in the designated voice_client in the prompted language."""
+    voice_client = getattr(ctx, "voice_client", None)
+    if voice_client is None or not voice_client.is_connected():
+        await ctx.send("I'm not connected to a voice channel. Please summon me with `!join` first.")
+        return
+
+    folder_path = Path("cogs/TextToSpeechFiles")
+    folder_path.mkdir(parents=True, exist_ok=True)
 
     tts = gTTS(text=text, lang=language)
-
-    file_path = os.path.join(folder_path, "tts.mp3")
+    file_path = folder_path / f"tts_{uuid.uuid4().hex}.mp3"
     tts.save(file_path)
+
+    guild_id = _get_guild_id(ctx)
+    lock = _play_locks.setdefault(guild_id, asyncio.Lock())
+
     try:
-        ctx.voice_client.play(discord.FFmpegPCMAudio('cogs/TextToSpeechFiles/tts.mp3'))
-        print(f"Finished playing: {tts.text}")
+        async with lock:
+            voice_client = getattr(ctx, "voice_client", None)
+            if voice_client is None or not voice_client.is_connected():
+                await ctx.send("I was disconnected before I could speak. Please use `!join` again.")
+                return
+
+            while voice_client.is_playing() or voice_client.is_paused():
+                await asyncio.sleep(0.05)
+
+            source = discord.FFmpegPCMAudio(str(file_path))
+            await _wait_for_completion(ctx, voice_client, source)
+            print(f"Finished playing: {tts.text}")
     except ClientException as e:
-        await ctx.send(f"A client exception occured:\n`{e}`")
+        await ctx.send(f"A client exception occurred:\n`{e}`")
     except TypeError as e:
         await ctx.send(f"TypeError exception:\n`{e}`")
     except OpusNotLoaded as e:
         await ctx.send(f"OpusNotLoaded exception: \n`{e}`")
+    finally:
+        if 'source' in locals():
+            source.cleanup()
+        try:
+            os.remove(file_path)
+        except OSError:
+            pass
 
 
 # Helper to determine whether text is in chinese


### PR DESCRIPTION
## Summary
- coordinate text-to-speech playback with guild-level locks, temporary audio files, and improved error handling
- simplify praise and say commands to reuse the shared playback queue and guard against missing voice connections
- prevent duplicate praise entries and require an active voice connection before running the League monitor

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e0ca79d7e48330a3965785c87a4352